### PR TITLE
Update styles.scss to handle bad position of crosshair

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -4,7 +4,7 @@ body {
 }
 
 .crosshairs {
-  position: absolute;
+  position: fixed;
   width: 100%;
   z-index: 2147483645;
 }


### PR DESCRIPTION
This way crosshairs will be handled in nested elements which are way deep down in the DOM and will not affect the behavior for simple single page component. Give it a try.

For me its treating the parent element as the main browser window and when I got to 10px clientX 10px clientY it goes to the pixels of the parent element hosting ScreenCapture