### PR TITLE
Fixed crop position issue for screens > 1080p

### DIFF
--- a/src/ScreenCapture.tsx
+++ b/src/ScreenCapture.tsx
@@ -134,6 +134,8 @@ export default class ScreenCapture extends Component<Props, State> {
     
     cropWidth *= window.devicePixelRatio;
     cropHeigth *= window.devicePixelRatio;
+    cropPositionLeft *= window.devicePixelRatio;
+    cropPositionTop *= window.devicePixelRatio;
 
     this.setState({
       crossHairsTop: e.clientY,


### PR DESCRIPTION
There is a bug in `react-screen-capture` because of which the screenshot taken on screens greater than 1080p aren't correct. 

Also mentioned in this issue: [Seems to break on all screens above 1080p #10 ](https://github.com/Bunlong/react-screen-capture/issues/10) 

Checkout the video attached: 

https://github.com/Bunlong/react-screen-capture/assets/28836523/550d4b98-3f85-4672-abe8-9a558a037438

The video is recorded on an `Apple M1 Pro`
